### PR TITLE
25.09.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 
 on:
   workflow_dispatch: # Allows manual execution
-  schedule:
-    - cron: "0 0 1 * *" # Runs on the 1st of every month
+  push:
+    branches:
+      - main
 
 jobs:
   ci:
@@ -57,7 +58,7 @@ jobs:
         with:
           sarif_file: snyk.sarif
       - name: Create tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,30 @@
+---
+name: Snyk Container Scan
+
+on:
+  workflow_dispatch: # Allows manual execution
+  schedule:
+    - cron: "0 0 1 * *" # Runs on the 1st of every month
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Snyk vulnerability scan
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ghcr.io/${{ github.actor }}/caddy-docker-proxy-cloudflare:latest
+          args: --file=Dockerfile
+      - name: Upload Snyk vulnerability scan results to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/caddy:2.10.0-builder-alpine AS builder
+FROM docker.io/caddy:2.10.2-builder-alpine AS builder
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare@35fb847 \
-    --with github.com/lucaslorentz/caddy-docker-proxy@v2.9.2
+    --with github.com/caddy-dns/cloudflare@f589a18 \
+    --with github.com/lucaslorentz/caddy-docker-proxy@v2.10.0
 
-FROM docker.io/caddy:2.10.0-alpine
+FROM docker.io/caddy:2.10.2-alpine
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ I have some low powered ARM based devices (Raspberry Pis) where building the ima
 
 No.
 
-### Is this container image kept up to date?ß
+### Is this container image kept up to date?
+
 - [Renovate](renovate.json) is configured to create pull requests when dependencies are updated.
 - Snyk is used to scan the container image for vulnerabilities on the 1st of every month.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # caddy-docker-proxy-cloudflare
 
 ![CI](https://github.com/dbrennand/caddy-docker-proxy-cloudflare/actions/workflows/ci.yml/badge.svg)
+![Snyk Container Scan](https://github.com/dbrennand/caddy-docker-proxy-cloudflare/actions/workflows/snyk.yml/badge.svg)
+
 
 Caddy container image with [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) and [Cloudflare DNS](https://github.com/caddy-dns/cloudflare) modules. Built for ARM and AMD64 CPU architectures.
 
@@ -14,11 +16,9 @@ I have some low powered ARM based devices (Raspberry Pis) where building the ima
 
 No.
 
-### Is this container image kept up to date?
-
-- A [GitHub Action](.github/workflows/ci.yml) is set up with a cron schedule to re-build the image on the 1st of every month.
+### Is this container image kept up to date?ß
 - [Renovate](renovate.json) is configured to create pull requests when dependencies are updated.
-- Snyk is used to scan the container image for vulnerabilities.
+- Snyk is used to scan the container image for vulnerabilities on the 1st of every month.
 
 ## License 📝
 
@@ -26,4 +26,4 @@ No.
 
 ## Contributors
 
-[dbrennand](https://github.com/dbrennand)
+[Daniel Brennand](https://github.com/dbrennand)

--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,12 @@
     "regexManagers": [
         {
             "fileMatch": [
-                "^Dockerfile$"
+                "Dockerfile"
             ],
             "matchStrings": [
-                "--with\\s+(?<depName>github\\.com/[^@\\s]+)@(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+                "--with github.com/(?<depName>.*?)(?:@(?<currentValue>.*?))?\\s"
             ],
-            "datasourceTemplate": "github-tags",
-            "depNameTemplate": "{{{depName}}}",
-            "versioningTemplate": "semver"
+            "datasourceTemplate": "github-releases"
         }
     ]
 }


### PR DESCRIPTION
* Bump `github.com/caddy-dns/cloudflare` to commit `f589a18`.
* Bump `github.com/lucaslorentz/caddy-docker-proxy` to GitHub Release `v2.10.0`
* Bump Caddy version to `2.10.2`.
* Stop building once a month when nothing has changed, scan for vulnerabilities once a month in the image instead.