### PR TITLE
Pin GitHub Actions to commit SHAs and bump Caddy and plugin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,25 +24,25 @@ jobs:
         run: echo "CalVer version ${{ steps.calver.outputs.CALVER }}"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           context: .
@@ -53,11 +53,12 @@ jobs:
 
       - name: Snyk vulnerability scan
         continue-on-error: true
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: ghcr.io/${{ github.actor }}/caddy-docker-proxy-cloudflare:${{ steps.calver.outputs.CALVER }}
+          image: ghcr.io/${{ github.actor }}/caddy-docker-proxy-cloudflare:${{
+            steps.calver.outputs.CALVER }}
           args: --file=Dockerfile
 
       - name: Replace security-severity undefined or null for license-related findings
@@ -67,12 +68,12 @@ jobs:
 
       - name: Upload Snyk vulnerability scan results to GitHub Code Scanning
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: snyk.sarif
 
       - name: Create tag
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,11 +14,11 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Snyk vulnerability scan
         continue-on-error: true
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -32,6 +32,6 @@ jobs:
 
       - name: Upload Snyk vulnerability scan results to GitHub Code Scanning
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: snyk.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/caddy:2.10.2-builder-alpine AS builder
+FROM docker.io/caddy:2.11.2-builder-alpine AS builder
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare@f589a18 \
-    --with github.com/lucaslorentz/caddy-docker-proxy/v2@44f27c8
+    --with github.com/caddy-dns/cloudflare@a8737d095ad5a48ca031cea6ab704057dbc2d250 # v0.2.4 \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2@2eafc7ee742e77eacfc78f2c64095bc396eb3ea6 # v2.12.0
 
-FROM docker.io/caddy:2.10.2-alpine
+FROM docker.io/caddy:2.11.2-alpine
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Daniel Brennand
+Copyright (c) 2026 Daniel Brennand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,9 @@
                 "Dockerfile"
             ],
             "matchStrings": [
-                "--with github.com/(?<depName>.*?)(?:@(?<currentValue>.*?))?\\s"
+                "--with github\\.com/(?<depName>[^@]+?)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<currentValue>[^\\s\\\\]+)"
             ],
+            "depNameTemplate": "{{replace '/v\\d+$' '' depName}}",
             "datasourceTemplate": "github-tags",
             "versioningTemplate": "semver-coerced"
         }


### PR DESCRIPTION
This PR hardens supply chain security and brings all dependencies up to date.

All GitHub Actions are now pinned to their commit SHAs (with the version tag preserved as an inline comment) so we're protected against a tag being silently moved or deleted. Renovate has also been fixed to keep these digests current automatically.

## Changes

- Pin all GitHub Actions to commit SHAs in `ci.yml` and `snyk.yml`
- Bump Caddy base image from `2.10.2` to `2.11.2` (patches 8 CVEs — see below)
- Update `caddy-dns/cloudflare` from `f589a18` to `v0.2.4`
- Update `caddy-docker-proxy` from `44f27c8` to `v2.12.0`
- Switch Dockerfile plugin references to full 40-char SHAs with version tag comments for Renovate digest tracking
- Fix `renovate.json` regex to capture `currentDigest` + `currentValue` and strip Go module major version suffix from `depName`

## Caddy 2.11.2 security fixes

- `CVE-2026-27590` — FastCGI Unicode case-folding causes SCRIPT_NAME/PATH_INFO confusion
- `CVE-2026-27589` — Admin API cross-origin `no-cors` requests could succeed
- `CVE-2026-27588` — Host matcher case-insensitive for large host lists, enabling auth bypass
- `CVE-2026-27587` — Path matcher skipped case normalisation for escape sequences, enabling auth bypass
- `CVE-2026-27586` — TLS client auth silently failed open with missing/malformed CA cert
- `CVE-2026-27585` — Glob characters in file matcher not sanitised, bypassing security rules
- `forward_auth` directive permitted identity injection and privilege escalation
- `vars_regexp` double-expanded placeholders, potentially revealing secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)