### PR TITLE
Update Caddy and GitHub Actions dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "CalVer version ${{ steps.calver.outputs.CALVER }}"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Snyk vulnerability scan results to GitHub Code Scanning
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: snyk.sarif
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Snyk vulnerability scan
         continue-on-error: true
@@ -32,6 +32,6 @@ jobs:
 
       - name: Upload Snyk vulnerability scan results to GitHub Code Scanning
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: snyk.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/caddy:2.11.3-builder-alpine AS builder
+FROM docker.io/caddy:2.11.4-builder-alpine AS builder
 
 RUN xcaddy build \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2@03253c239b6fffd2e471b75ee2e5d980692ce44d \
     --with github.com/caddy-dns/cloudflare@a8737d095ad5a48ca031cea6ab704057dbc2d250
 
-FROM docker.io/caddy:2.11.3-alpine
+FROM docker.io/caddy:2.11.4-alpine
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 


### PR DESCRIPTION
## Summary
This PR folds in the currently open dependency update PRs into a single branch. It bumps the Caddy base image to `2.11.4` and refreshes the pinned GitHub Actions references used by the CI and Snyk workflows.

## Changes
- `Dockerfile`: Updates both the builder and runtime `docker.io/caddy` base images from `2.11.3` to `2.11.4`.
- `.github/workflows/ci.yml`: Updates the pinned `actions/checkout` reference to `v6.0.3` and refreshes the pinned `github/codeql-action/upload-sarif` digest.
- `.github/workflows/snyk.yml`: Updates the pinned `actions/checkout` reference and refreshes the pinned `github/codeql-action/upload-sarif` digest to match the CI workflow.